### PR TITLE
Add support for PHP 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See [`composer.json`](composer.json) for depenencides.
 ## What's inside?
 
 -   **`Charcoal\ReCaptcha\CaptchaServiceProvider`**: 
-    Pimple service provider.
+    Service provider.
 -   **`Charcoal\ReCaptcha\CaptchaConfig`**: 
     Configuring the CAPTCHA service.
 -   **`Charcoal\ReCaptcha\CaptchaAwareTrait`**: 
@@ -200,7 +200,6 @@ This package is inspired by:
 [charcoal/app]:        https://packagist.org/packages/locomotivemtl/charcoal-app
 [charcoal/translator]: https://packagist.org/packages/locomotivemtl/charcoal-translator
 
-[pimple]:              https://packagist.org/packages/pimple/pimple
 [google/recaptcha]:    https://packagist.org/packages/google/recaptcha
 [class-recaptcha]:     https://github.com/google/recaptcha/blob/1.1.3/src/ReCaptcha/ReCaptcha.php
 

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
         }
     },
     "require": {
-        "php": ">=8.0",
-        "pimple/pimple": "^3.0",
+        "php": ">=5.6.0 || >=7.0",
         "psr/http-message": "^1.0",
         "google/recaptcha": "^1.1",
         "locomotivemtl/charcoal-config": "~0.8",
@@ -30,7 +29,7 @@
     },
     "require-dev": {
         "slim/slim": "^3.4",
-        "phpunit/phpunit": "^5.7 || ^6.5",
+        "phpunit/phpunit": "^5.7 || ^6.5 || ^12.0",
         "squizlabs/php_codesniffer": "^3.0",
         "php-coveralls/php-coveralls": "^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,12 @@
         }
     },
     "require": {
-        "php": ">=5.6.0 || >=7.0",
+        "php": ">=8.0",
         "pimple/pimple": "^3.0",
         "psr/http-message": "^1.0",
         "google/recaptcha": "^1.1",
-        "locomotivemtl/charcoal-config": "~0.8"
+        "locomotivemtl/charcoal-config": "~0.8",
+        "php-di/php-di": "^7.0"
     },
     "require-dev": {
         "slim/slim": "^3.4",

--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -408,7 +408,7 @@ class Captcha
      * @param  array|null $query Array of query string arguments to customize the API.
      * @return string Returns an HTML `<script>` element.
      */
-    public function getJsHtml(array $query = null)
+    public function getJsHtml(?array $query = null)
     {
         return sprintf(
             '<script src="%s" async defer></script>',
@@ -423,7 +423,7 @@ class Captcha
      * @param  array $query Array of query string arguments to customize the API.
      * @return string Returns a URI.
      */
-    public function getJsUri(array $query = null)
+    public function getJsUri(?array $query = null)
     {
         if (isset($query['lang'])) {
             $query['hl'] = $query['lang'];

--- a/src/CaptchaServiceProvider.php
+++ b/src/CaptchaServiceProvider.php
@@ -2,16 +2,14 @@
 
 namespace Charcoal\ReCaptcha;
 
-// From Pimple
-use DI\Container;
-
 // From Google
 use ReCaptcha\ReCaptcha;
-
 // From 'charcoal-recaptcha'
 use Charcoal\ReCaptcha\Captcha;
 use Charcoal\ReCaptcha\CaptchaConfig;
 use Charcoal\ReCaptcha\LocalizedCaptcha;
+use Psr\Container\ContainerInterface;
+use DI\Container;
 
 /**
  * Google reCAPTCHA Service Provider
@@ -24,7 +22,7 @@ class CaptchaServiceProvider
      * @param  Container $container A DI container.
      * @return void
      */
-    public function register(Container $container)
+    public function register(ContainerInterface $container)
     {
         /**
          * Setup the Google reCaptcha service configuration.
@@ -32,7 +30,7 @@ class CaptchaServiceProvider
          * @param  Container $container A container instance.
          * @return CaptchaConfig
          */
-        $container->set('charcoal/captcha/config', function (Container $container) {
+        $container->set('charcoal/captcha/config', function (ContainerInterface $container) {
             $appConfig = $container->get('config');
 
             return new CaptchaConfig($appConfig['apis.google.recaptcha']);
@@ -44,7 +42,7 @@ class CaptchaServiceProvider
          * @param  Container $container A container instance.
          * @return Captcha
          */
-        $container->set('charcoal/captcha', function (Container $container) {
+        $container->set('charcoal/captcha', function (ContainerInterface $container) {
             $args = [
                 'config' => $container->get('charcoal/captcha/config')
             ];

--- a/src/CaptchaServiceProvider.php
+++ b/src/CaptchaServiceProvider.php
@@ -3,8 +3,7 @@
 namespace Charcoal\ReCaptcha;
 
 // From Pimple
-use Pimple\Container;
-use Pimple\ServiceProviderInterface;
+use DI\Container;
 
 // From Google
 use ReCaptcha\ReCaptcha;
@@ -17,7 +16,7 @@ use Charcoal\ReCaptcha\LocalizedCaptcha;
 /**
  * Google reCAPTCHA Service Provider
  */
-class CaptchaServiceProvider implements ServiceProviderInterface
+class CaptchaServiceProvider
 {
     /**
      * Register Google reCAPTCHA.
@@ -33,11 +32,11 @@ class CaptchaServiceProvider implements ServiceProviderInterface
          * @param  Container $container A container instance.
          * @return CaptchaConfig
          */
-        $container['charcoal/captcha/config'] = function (Container $container) {
-            $appConfig = $container['config'];
+        $container->set('charcoal/captcha/config', function (Container $container) {
+            $appConfig = $container->get('config');
 
             return new CaptchaConfig($appConfig['apis.google.recaptcha']);
-        };
+        });
 
         /**
          * Add the Charcoal reCaptcha Service
@@ -45,19 +44,19 @@ class CaptchaServiceProvider implements ServiceProviderInterface
          * @param  Container $container A container instance.
          * @return Captcha
          */
-        $container['charcoal/captcha'] = function (Container $container) {
+        $container->set('charcoal/captcha', function (Container $container) {
             $args = [
-                'config' => $container['charcoal/captcha/config']
+                'config' => $container->get('charcoal/captcha/config')
             ];
 
-            if (isset($container['translator'])) {
-                $args['translator'] = $container['translator'];
+            if ($container->has('translator')) {
+                $args['translator'] = $container->get('translator');
                 $captcha = new LocalizedCaptcha($args);
             } else {
                 $captcha = new Captcha($args);
             }
 
             return $captcha;
-        };
+        });
     }
 }

--- a/tests/CaptchaFactoryTrait.php
+++ b/tests/CaptchaFactoryTrait.php
@@ -27,7 +27,7 @@ trait CaptchaFactoryTrait
      * @param  ReCaptcha|null $client The ReCaptcha client.
      * @return Captcha
      */
-    protected function createAdapter(ReCaptcha $client = null)
+    protected function createAdapter(?ReCaptcha $client = null)
     {
         return new Captcha([
             'config' => $this->getConfig(),


### PR DESCRIPTION
This update fixes any deprecation warnings and updates the dependency injection container from [Pimple](https://github.com/silexphp/Pimple) to [PHP-DI](https://php-di.org/).

This is only compatible with [the next version of charcoal](https://github.com/charcoalphp/charcoal/tree/feature/php8) since this is not compatible with the Pimple DI container.